### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip install -q -r requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip_tools.txt requirements/pip_tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip_tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/quality.txt requirements/quality.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ numpy==1.22.4
     #   scipy
 pyparsing==3.0.9
     # via -r requirements/base.in
-regex==2022.4.24
+regex==2022.6.2
     # via nltk
 scipy==1.8.1
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,13 +8,13 @@ click==8.1.3
     # via
     #   -r requirements/test.txt
     #   nltk
-coverage==6.4
+coverage==6.4.1
     # via -r requirements/test.txt
 distlib==0.3.4
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-filelock==3.7.0
+filelock==3.7.1
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -52,7 +52,7 @@ pyparsing==3.0.9
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
     #   packaging
-regex==2022.4.24
+regex==2022.6.2
     # via
     #   -r requirements/test.txt
     #   nltk

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/quality.txt requirements/quality.in
 #
-astroid==2.11.5
+astroid==2.11.6
     # via pylint
 click==8.1.3
     # via
@@ -34,17 +34,19 @@ platformdirs==2.5.2
     # via pylint
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pylint==2.13.9
+pylint==2.14.1
     # via -r requirements/quality.in
 pyparsing==3.0.9
     # via -r requirements/base.txt
-regex==2022.4.24
+regex==2022.6.2
     # via
     #   -r requirements/base.txt
     #   nltk
 scipy==1.8.1
     # via -r requirements/base.txt
 tomli==2.0.1
+    # via pylint
+tomlkit==0.11.0
     # via pylint
 tqdm==4.64.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ click==8.1.3
     # via
     #   -r requirements/base.txt
     #   nltk
-coverage==6.4
+coverage==6.4.1
     # via -r requirements/test.in
 joblib==1.1.0
     # via
@@ -24,7 +24,7 @@ numpy==1.22.4
     #   scipy
 pyparsing==3.0.9
     # via -r requirements/base.txt
-regex==2022.4.24
+regex==2022.6.2
     # via
     #   -r requirements/base.txt
     #   nltk

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -6,7 +6,7 @@
 #
 distlib==0.3.4
     # via virtualenv
-filelock==3.7.0
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3447